### PR TITLE
fix: 🐛 reactive queries

### DIFF
--- a/src/lib/components/Content.svelte
+++ b/src/lib/components/Content.svelte
@@ -2,6 +2,7 @@
   import { createCombobox, melt } from "@melt-ui/svelte";
   import { createQuery } from "@tanstack/svelte-query";
   import { Check } from "lucide-svelte";
+  import { derived } from "svelte/store";
 
   import Line from "./Line.svelte";
 
@@ -44,14 +45,18 @@
   $: allMembers = ($allMembersQuery.isSuccess ? $allMembersQuery.data : []) as GetMembers;
   let filteredMembers = [] as GetMembers;
 
-  $: filteredMembersQuery = createQuery<GetMembers>({
-    queryKey: ["members", $inputValue],
-    queryFn: async () => {
-      const params = new URLSearchParams();
-      params.set("search", $inputValue);
-      return (await fetch("/api/members?" + params)).json();
-    },
+  const queryOptions = derived(inputValue, ($inputValue) => {
+    return {
+      queryKey: ["members", $inputValue],
+      queryFn: async () => {
+        const params = new URLSearchParams();
+        params.set("search", $inputValue);
+        return (await fetch("/api/members?" + params)).json();
+      },
+    };
   });
+
+  const filteredMembersQuery = createQuery<GetMembers>(queryOptions);
 
   $: if ($filteredMembersQuery.isSuccess === true) filteredMembers = $filteredMembersQuery.data;
 </script>

--- a/src/lib/components/Selector.svelte
+++ b/src/lib/components/Selector.svelte
@@ -2,6 +2,7 @@
   import { createPopover, melt } from "@melt-ui/svelte";
   import { createQuery } from "@tanstack/svelte-query";
   import { ChevronsUpDown } from "lucide-svelte";
+  import { derived } from "svelte/store";
   import { fade } from "svelte/transition";
 
   import Content from "./Content.svelte";
@@ -9,10 +10,14 @@
   import type { GetMember } from "$api/members/[id]";
   import { page } from "$app/stores";
 
-  $: memberQuery = createQuery<GetMember>({
-    queryKey: ["members", $page.params.selectedMember],
-    queryFn: async () => (await fetch(`/api/members/${$page.params.selectedMember}`)).json(),
+  const queryOptions = derived(page, ($page) => {
+    return {
+      queryKey: ["members", $page.params.selectedMember],
+      queryFn: async () => (await fetch(`/api/members/${$page.params.selectedMember}`)).json(),
+    };
   });
+
+  const memberQuery = createQuery<GetMember>(queryOptions);
 
   const {
     elements: { trigger, content },


### PR DESCRIPTION
# Summary
Create reactive queries per the v5 guide https://tanstack.com/query/latest/docs/svelte/reactivity

## TODO
I didn't actually confirm if anything worked, because I wasn't sure how to get everything working correctly (skill issue).

## Technical details:
- One of the few L's of Svelte's design is that its reactivity is very coarse; creating reactive queries with the $ syntax recreates them every single time its nested stores change. Doing the $ syntax was actually incorrectly recommended in the v4 documentation
- It should've been fixed in the v5 implementation and docs
- Basically you pass in a store as the options, and the svelte-query internals will do the subscription itself

P.S. I just tried this yesterday, but passing in a query options store specifically to toggle the `enable` flag on/off doesn't seem to work? So there might still be some upstream issues with the reactivity implementation. Hopefully they're not relevant here