### PR TITLE
Fix: Loading Line Overlaps

### DIFF
--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -94,6 +94,7 @@
   }
 
   .overlay {
+    z-index: 999;
     position: fixed;
     inset: 0;
     background-color: rgba(0, 0, 0, 0.7);

--- a/src/lib/components/Drawer.svelte
+++ b/src/lib/components/Drawer.svelte
@@ -61,14 +61,14 @@
   .overlay {
     position: fixed;
     inset: 0;
-    z-index: 50;
+    z-index: 999;
     background-color: var(--gray600);
     opacity: 0.5;
   }
 
   .content {
     position: fixed;
-    z-index: 50;
+    z-index: 1000;
     padding: 1.5rem;
     background-color: var(--background);
     box-shadow:

--- a/src/lib/components/Selector.svelte
+++ b/src/lib/components/Selector.svelte
@@ -96,6 +96,7 @@
   }
 
   .content {
+    z-index: 1000;
     position: absolute;
     border-radius: 12px;
     border: 1px solid var(--gray100);


### PR DESCRIPTION
Increased the `z-height` of overlapping elements to ensure loading line is underneath.